### PR TITLE
fix: セキュリティバグ・ランタイムバグ・HTTPステータスコードの修正

### DIFF
--- a/api/auth.ts
+++ b/api/auth.ts
@@ -2,8 +2,6 @@
 
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
-import { toast } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
 /**
  * ログイン用のAPI
  * @param formData メールアドレスとパスワードのフォームデータ
@@ -38,7 +36,13 @@ export async function signup(formData: FormData) {
     name: formData.get("name") as string,
   };
   // サインアップ処理
-  const { data, error } = await supabase.auth.signUp(inputData);
+  const { data, error } = await supabase.auth.signUp({
+    email: inputData.email,
+    password: inputData.password,
+    options: {
+      data: { name: inputData.name },
+    },
+  });
 
   if (error) {
     console.error("サインアップエラー:", error);
@@ -51,7 +55,6 @@ export async function signup(formData: FormData) {
       {
         id: userId,
         email: inputData.email,
-        password: inputData.password,
         name: inputData.name,
       },
     ]);
@@ -72,7 +75,6 @@ export const checkAuth = async () => {
   } = await supabase.auth.getUser();
 
   if (!user || error) {
-    toast.error(error?.message || "認証ユーザーが存在しませんでした。");
     redirect("/login");
   }
 

--- a/app/api/angerlog/[angerId]/route.ts
+++ b/app/api/angerlog/[angerId]/route.ts
@@ -1,5 +1,6 @@
 import prisma from "../../../../utils/prisma";
 import { NextResponse } from "next/server";
+import { checkAuth } from "@/api/auth";
 
 type PageProps = {
   params: Promise<{
@@ -14,6 +15,9 @@ type PageProps = {
  */
 export async function GET(request: Request, { params }: PageProps) {
   try {
+    // ユーザ認証
+    const user = await checkAuth();
+
     // アンガーログID取得
     const angerId = parseInt((await params).angerId);
 
@@ -22,17 +26,17 @@ export async function GET(request: Request, { params }: PageProps) {
       return new Response("Invalid ID", { status: 400 });
     }
 
-    // アンガーログデータ取得
+    // アンガーログデータ取得（所有権確認込み）
     const record = await prisma.angerRecord.findUnique({
       where: { id: angerId },
     });
 
-    if (!record) {
+    if (!record || record.userId !== user.id) {
       return new Response("Not Found", { status: 404 });
     }
     return NextResponse.json(record);
   } catch (error) {
-    console.error("Error during POST request:", error);
+    console.error("Error during GET request:", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }

--- a/app/api/angerlog/chart/route.ts
+++ b/app/api/angerlog/chart/route.ts
@@ -9,9 +9,6 @@ import { getDateRange } from "../../utils/dateUtils";
  * @returns アンガーログのチャートデータ　最大値、平均値、カテゴリトップ5
  */
 export async function GET(request: Request) {
-  // ユーザ認証
-  const user = await checkAuth();
-  const userId = user.id;
   // パラメータ取得
   const { searchParams } = new URL(request.url);
   const year = searchParams.get("year");
@@ -20,6 +17,10 @@ export async function GET(request: Request) {
   const type = searchParams.get("type") as "daily" | "monthly";
 
   try {
+    // ユーザ認証
+    const user = await checkAuth();
+    const userId = user.id;
+
     if (type !== "daily" && type !== "monthly") {
       return NextResponse.json({ error: "Invalid type parameter" }, { status: 400 });
     }

--- a/app/api/angerlog/detail/route.ts
+++ b/app/api/angerlog/detail/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import prisma from "../../../../utils/prisma";
+import { checkAuth } from "@/api/auth";
 
 /**
  * アンガーログのデータを取得するAPI
@@ -14,17 +15,20 @@ export async function GET(request: Request) {
     return new Response("Invalid ID", { status: 400 });
   }
   try {
-    // アンガーログデータ取得
+    // ユーザ認証
+    const user = await checkAuth();
+
+    // アンガーログデータ取得（所有権確認込み）
     const record = await prisma.angerRecord.findUnique({
       where: { id: parseInt(angerId) },
     });
 
-    if (!record) {
+    if (!record || record.userId !== user.id) {
       return new Response("Not Found", { status: 404 });
     }
     return NextResponse.json(record);
   } catch (error) {
-    console.error("Error during POST request:", error);
+    console.error("Error during GET request:", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }

--- a/app/api/angerlog/route.ts
+++ b/app/api/angerlog/route.ts
@@ -10,12 +10,14 @@ import { getDateRange } from "../utils/dateUtils";
  */
 export async function POST(request: Request) {
   try {
+    // ユーザ認証
+    const user = await checkAuth();
     const body = await request.json();
-    const { userId, level, workTypeId, occurredDate, situation, feeling } = body;
+    const { level, workTypeId, occurredDate, situation, feeling } = body;
     // アンガーログデータ登録
     const record = await prisma.angerRecord.create({
       data: {
-        userId,
+        userId: user.id,
         level,
         workTypeId,
         occurredDate,
@@ -37,11 +39,13 @@ export async function POST(request: Request) {
  */
 export async function PUT(request: Request) {
   try {
+    // ユーザ認証
+    const user = await checkAuth();
     const body = await request.json();
     const { id, level, workTypeId, occurredDate, situation, feeling } = body;
-    // アンガーログデータ更新
-    const record = await prisma.angerRecord.update({
-      where: { id },
+    // アンガーログデータ更新（所有権確認込み）
+    const record = await prisma.angerRecord.updateMany({
+      where: { id, userId: user.id },
       data: {
         level,
         workTypeId,
@@ -51,9 +55,12 @@ export async function PUT(request: Request) {
       },
     });
 
-    return NextResponse.json(record, { status: 201 });
+    if (record.count === 0) {
+      return NextResponse.json({ error: "Not Found" }, { status: 404 });
+    }
+    return NextResponse.json(record, { status: 200 });
   } catch (error) {
-    console.error("Error during POST request:", error);
+    console.error("Error during PUT request:", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }
@@ -63,9 +70,6 @@ export async function PUT(request: Request) {
  * @returns アンガーログデータ
  */
 export async function GET(request: Request) {
-  // ユーザ認証
-  const user = await checkAuth();
-  const userId = user.id;
   // パラメータ取得
   const { searchParams } = new URL(request.url);
   const year = searchParams.get("year");
@@ -74,6 +78,10 @@ export async function GET(request: Request) {
   const type = searchParams.get("type") as "daily" | "monthly";
 
   try {
+    // ユーザ認証
+    const user = await checkAuth();
+    const userId = user.id;
+
     if (type !== "daily" && type !== "monthly") {
       return NextResponse.json({ error: "Invalid type parameter" }, { status: 400 });
     }

--- a/app/api/task/route.ts
+++ b/app/api/task/route.ts
@@ -36,22 +36,25 @@ export async function POST(request: Request) {
  */
 export async function PUT(request: Request) {
   try {
+    // ユーザ認証
+    const user = await checkAuth();
     const body = await request.json();
-    const { id, category,
-      content,
-    } = body;
-    // 作業内容データ更新
-    const record = await prisma.workContent.update({
-      where: { id },
+    const { id, category, content } = body;
+    // 作業内容データ更新（所有権確認込み）
+    const record = await prisma.workContent.updateMany({
+      where: { id, userId: user.id },
       data: {
         category,
         content,
       },
     });
 
-    return NextResponse.json(record, { status: 201 });
+    if (record.count === 0) {
+      return NextResponse.json({ error: "Not Found" }, { status: 404 });
+    }
+    return NextResponse.json(record, { status: 200 });
   } catch (error) {
-    console.error("Error during POST request:", error);
+    console.error("Error during PUT request:", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }
@@ -62,17 +65,21 @@ export async function PUT(request: Request) {
  */
 export async function DELETE(request: Request) {
   try {
+    // ユーザ認証
+    const user = await checkAuth();
     const body = await request.json();
-    const { id
-    } = body;
-    // 作業内容データ削除
-    const record = await prisma.workContent.delete({
-      where: { id },
+    const { id } = body;
+    // 作業内容データ削除（所有権確認込み）
+    const record = await prisma.workContent.deleteMany({
+      where: { id, userId: user.id },
     });
 
-    return NextResponse.json(record, { status: 201 });
+    if (record.count === 0) {
+      return NextResponse.json({ error: "Not Found" }, { status: 404 });
+    }
+    return NextResponse.json(record, { status: 200 });
   } catch (error) {
-    console.error("Error during POST request:", error);
+    console.error("Error during DELETE request:", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }

--- a/components/molecules/AngerLogForm.tsx
+++ b/components/molecules/AngerLogForm.tsx
@@ -7,7 +7,6 @@ import { Box, Button } from "@mui/material";
 import { useRouter } from "next/navigation";
 import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import { checkAuth } from "@/api/auth";
 import Loading from "@/app/loading";
 
 export type AngerLog = {
@@ -156,8 +155,6 @@ const AngerLogForm = ({
     const toastId = toast.loading("処理中・・・・。");
 
     try {
-      // ユーザー認証
-      const user = await checkAuth();
       const occurredDateTimeZone = new Date(
         `${formData.date}T${formData.time}`
       ).toISOString();
@@ -168,7 +165,6 @@ const AngerLogForm = ({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          userId: user.id,
           level: formData.level,
           workTypeId: formData.workTypeId,
           occurredDate: occurredDateTimeZone,
@@ -206,10 +202,10 @@ const AngerLogForm = ({
   const handleSubmit = async () => {
     if (mode === "edit" && angerId) {
       // 更新処理
-      handleUpdate();
+      await handleUpdate();
     } else {
       // 登録処理
-      handleInsert();
+      await handleInsert();
     }
   };
   // 更新処理

--- a/components/molecules/DataSelector.tsx
+++ b/components/molecules/DataSelector.tsx
@@ -79,8 +79,10 @@ const DataSelector: React.FC<DataSelectorProps> = ({ filter, onFilter }) => {
             onChange={(e) => setYear(e.target.value)}
             size="small"
           >
-            <MenuItem value="2024">2024</MenuItem>
-            <MenuItem value="2025">2025</MenuItem>
+            {Array.from({ length: 5 }, (_, i) => {
+              const y = (new Date().getFullYear() - 2 + i).toString();
+              return <MenuItem key={y} value={y}>{y}</MenuItem>;
+            })}
           </Select>
         </FormControl>
         <FormControl>

--- a/utils/apibase.ts
+++ b/utils/apibase.ts
@@ -8,7 +8,7 @@ const getApiBase = async () => {
   // ホストとプロトコル取得
   const headersData = headers();
   const protocol = (await headersData).get("x-forwarded-proto") || "http";
-  const host = (await headersData).get("host");
+  const host = (await headersData).get("host") || "localhost:3000";
   // 絶対パス
   const apiBase = `${protocol}://${host}`;
   return apiBase;


### PR DESCRIPTION
- [セキュリティ] サインアップ時にパスワードを平文でDBに保存していたのを修正
- [セキュリティ] POST /api/angerlog がリクエストボディの userId を信頼していた問題を修正（サーバー側で認証ユーザーIDを使用するよう変更）
- [セキュリティ] GET /api/angerlog/[angerId] に認証・所有権チェックを追加
- [セキュリティ] GET /api/angerlog/detail に認証・所有権チェックを追加
- [セキュリティ] PUT/DELETE /api/task に認証・所有権チェックを追加（updateMany/deleteManyで userId を条件に追加）
- [バグ] checkAuth() がサーバーアクションでクライアント専用の toast.error() を呼んでいた問題を修正
- [バグ] GET ハンドラで checkAuth() が try-catch の外で呼ばれていた問題を修正
- [バグ] handleSubmit で handleUpdate/handleInsert の await が欠けていた問題を修正
- [バグ] PUT/DELETE エンドポイントが誤って 201 を返していたのを 200 に修正
- [バグ] getApiBase で host ヘッダーが null の場合 "http://null" になる問題を修正
- [改善] 年セレクターのハードコード（2024-2025 固定）を現在年基準の動的生成に変更
- [改善] supabase.auth.signUp() に name を正しく options.data 経由で渡すよう修正

https://claude.ai/code/session_01K3q4N25GrFNuJ3qf3UCtBw